### PR TITLE
Fix broken item links

### DIFF
--- a/src/Web/AuctionSystem.Web/ViewModels/Item/ItemListingDto.cs
+++ b/src/Web/AuctionSystem.Web/ViewModels/Item/ItemListingDto.cs
@@ -16,7 +16,7 @@
 
         public string UserFullName { get; set; }
 
-        public string Url => $"details/{this.Id}/{this.Title.GenerateSlug()}";
+        public string Url => $"/items/details/{this.Id}/{this.Title.GenerateSlug()}";
 
         public ICollection<PictureDisplayViewModel> Pictures { get; set; }
     }


### PR DESCRIPTION
Use absolute URLs for items so that they work correctly on any page
Fixes #76 