### PR TITLE
Fix page selection not showing properly on small screens

### DIFF
--- a/src/Web/AuctionSystem.Web/Views/Items/List.cshtml
+++ b/src/Web/AuctionSystem.Web/Views/Items/List.cshtml
@@ -38,11 +38,15 @@
 @if (Model.Items.Any())
 {
     <ul class="pagination justify-content-center">
-        <li class="page-item @firstDisabled">
-            <a class="page-link" asp-route-pageIndex="1">First</a>
+        <li class="page-item @firstDisabled d-none d-md-inline-block">
+            <a class="page-link" asp-route-pageIndex="1">
+                <i class="fas fa-angle-double-left"></i>
+            </a>
         </li>
         <li class="page-item @prevDisabled">
-            <a class="page-link" asp-route-pageIndex="@(Model.Items.PageIndex - 1)">Previous</a>
+            <a class="page-link" asp-route-pageIndex="@(Model.Items.PageIndex - 1)">
+                <i class="fas fa-chevron-left"></i>
+            </a>
         </li>
 
         @for (int i = firstShownPage; i < Model.Items.PageIndex; i++)
@@ -64,10 +68,13 @@
         }
 
         <li class="page-item @nextDisabled">
-            <a class="page-link" asp-route-pageIndex="@(Model.Items.PageIndex + 1)">Next</a>
+            <a class="page-link" asp-route-pageIndex="@(Model.Items.PageIndex + 1)">
+                <i class="fas fa-chevron-right"></i>
+            </a>
         </li>
-        <li class="page-item @lastDisabled">
-            <a class="page-link" asp-route-pageIndex="@(Model.Items.TotalPages)">Last</a>
+        <li class="page-item @lastDisabled d-none d-md-inline-block">
+            <a class="page-link" asp-route-pageIndex="@(Model.Items.TotalPages)">
+                <i class="fas fa-angle-double-right"></i></a>
         </li>
     </ul>
 }


### PR DESCRIPTION
Fix page selection not showing properly on small screens by only showing the first and last page buttons on medium and larger screens, and by using icons instead of words for 'First', 'Next', etc.

Fixes #97 